### PR TITLE
feat: add scrolling in daily view and global selected day (#50)

### DIFF
--- a/app/components/line-chart.tsx
+++ b/app/components/line-chart.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
 	type ChartConfig,
 	ChartContainer,
@@ -27,7 +27,7 @@ const chartConfig = {
 
 export function ChartLineDefault({
 	chartData,
-	// chartTitle,
+	chartTitle,
 	unit,
 	children,
 }: {
@@ -41,7 +41,9 @@ export function ChartLineDefault({
 }) {
 	return (
 		<Card className="sm: w-full md:w-4/5 lg:w-3/4">
-			<CardHeader>{/* <CardTitle>{chartTitle}</CardTitle> */}</CardHeader>
+			<CardHeader>
+				<CardTitle>{chartTitle}</CardTitle>
+			</CardHeader>
 			<CardContent>
 				<ChartContainer config={chartConfig}>
 					<LineChart

--- a/app/lib/day-context.tsx
+++ b/app/lib/day-context.tsx
@@ -1,0 +1,39 @@
+import React, {
+	createContext,
+	type ReactNode,
+	useContext,
+	useState,
+} from "react";
+
+type ContextValue = {
+	selectedDay: Date;
+	setSelectedDay: (day: Date) => void;
+};
+
+const DayContext = createContext<ContextValue | undefined>(undefined);
+
+export const useDayContext = (): ContextValue => {
+	const context = useContext(DayContext);
+
+	if (!context) {
+		throw new Error("useDayContext must be used within a DayContextProvider");
+	}
+
+	return context;
+};
+
+type ContextProviderProps = {
+	children: ReactNode;
+};
+
+export const DayContextProvider: React.FC<ContextProviderProps> = ({
+	children,
+}) => {
+	const [selectedDay, setSelectedDay] = useState<Date>(new Date());
+
+	return (
+		<DayContext.Provider value={{ selectedDay, setSelectedDay }}>
+			{children}
+		</DayContext.Provider>
+	);
+};

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -10,6 +10,7 @@ import {
 } from "react-router";
 import type { Route } from "./+types/root";
 import "./app.css";
+import { DayContextProvider } from "./lib/day-context";
 
 export const links: Route.LinksFunction = () => [
 	{ rel: "preconnect", href: "https://fonts.googleapis.com" },
@@ -46,9 +47,11 @@ export function Layout({ children }: { children: React.ReactNode }) {
 export default function App() {
 	return (
 		<ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
-			<NuqsAdapter>
-				<Outlet />
-			</NuqsAdapter>
+			<DayContextProvider>
+				<NuqsAdapter>
+					<Outlet />
+				</NuqsAdapter>
+			</DayContextProvider>
 		</ThemeProvider>
 	);
 }

--- a/app/routes/dust.tsx
+++ b/app/routes/dust.tsx
@@ -7,13 +7,16 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@/ui/select";
+import { addDays, subDays } from "date-fns";
 import { useQueryState } from "nuqs";
 import { ChartLineDefault, ThresholdLine } from "../components/line-chart";
+import { Button } from "../components/ui/button";
 import { Calendar } from "../components/ui/calendar";
 import { Card } from "../components/ui/card";
 import { type Event as _Event, WeekView } from "../components/weekly-view";
 import dustChartData from "../dummy/dust_chart_data.json";
 import eventsData from "../dummy/weekly-events.json";
+import { useDayContext } from "../lib/day-context";
 
 const data = dustChartData;
 
@@ -47,31 +50,51 @@ const events: Array<_Event> = raw.map((e) => ({
 // biome-ignore lint: page components can be default exports
 export default function Dust() {
 	const [view, setView] = useQueryState("view", parseAsView.withDefault("day"));
+	const { selectedDay, setSelectedDay } = useDayContext();
 
 	return (
 		<main className="flex w-full flex-col place-items-center gap-4">
-			<Select
-				value={view}
-				onValueChange={(value) => setView(value as View | null)}
-			>
-				<SelectTrigger className="w-32">
-					<SelectValue placeholder="View" />
-				</SelectTrigger>
-				<SelectContent className="w-32">
-					<SelectItem key={"day"} value={"day"}>
-						{"Day"}
-					</SelectItem>
-					<SelectItem key={"week"} value={"week"}>
-						{"Week"}
-					</SelectItem>
-					<SelectItem key={"month"} value={"month"}>
-						{"Month"}
-					</SelectItem>
-				</SelectContent>
-			</Select>
+			<div className="flex gap-4">
+				{view === "day" && (
+					<Button
+						onClick={() => setSelectedDay(subDays(selectedDay, 1))}
+						size={"icon"}
+					>
+						{"<"}
+					</Button>
+				)}
+				<Select
+					value={view}
+					onValueChange={(value) => setView(value as View | null)}
+				>
+					<SelectTrigger className="w-32">
+						<SelectValue placeholder="View" />
+					</SelectTrigger>
+					<SelectContent className="w-32">
+						<SelectItem key={"day"} value={"day"}>
+							{"Day"}
+						</SelectItem>
+						<SelectItem key={"week"} value={"week"}>
+							{"Week"}
+						</SelectItem>
+						<SelectItem key={"month"} value={"month"}>
+							{"Month"}
+						</SelectItem>
+					</SelectContent>
+				</Select>
+				{view === "day" && (
+					<Button
+						onClick={() => setSelectedDay(addDays(selectedDay, 1))}
+						size={"icon"}
+					>
+						{">"}
+					</Button>
+				)}
+			</div>
 			{view === "month" ? (
 				<Card className="w-full md:w-4/5 lg:w-3/4">
 					<Calendar
+						defaultMonth={selectedDay}
 						fixedWeeks
 						showWeekNumber
 						disabled
@@ -96,7 +119,7 @@ export default function Dust() {
 			) : view === "week" ? (
 				<Card className="w-full md:w-4/5 lg:w-3/4">
 					<WeekView
-						initialDate={new Date()}
+						initialDate={selectedDay}
 						dayStartHour={8}
 						dayEndHour={16}
 						weekStartsOn={1}
@@ -108,7 +131,10 @@ export default function Dust() {
 			) : (
 				<ChartLineDefault
 					chartData={data}
-					chartTitle="Dust Exposure"
+					chartTitle={selectedDay.toLocaleDateString("en-GB", {
+						day: "numeric",
+						month: "long",
+					})}
 					unit="TWA"
 				>
 					<ThresholdLine y={120} dangerLevel="DANGER" />


### PR DESCRIPTION
- Added buttons to move to previous day and to next day in daily view.
- Added a global context with a selectedDay, this way we can remember what day we are on when we change pages.
- The buttons should be similar for all pages (day, week, month), but now we have three different solutions and maybe the customer can choose the one they like the best?


closes #50 